### PR TITLE
update: Routes updated.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,12 +16,12 @@ const config = {
   url: 'https://ticaretistatistik.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/docs/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'ticaretistatistik', // Usually your GitHub org/user name.
-  projectName: 'docs', // Usually your repo name.
+  projectName: 'ticaretistatistik.github.io', // Usually your repo name.
   trailingSlash: false,
 
   onBrokenLinks: 'throw',
@@ -45,14 +45,14 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/ticaretistatistik/docs/tree/main/',
+            'https://github.com/ticaretistatistik/ticaretistatistik.github.io/tree/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/ticaretistatistik/docs/tree/main/',
+            'https://github.com/ticaretistatistik/ticaretistatistik.github.io/tree/main/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -203,11 +203,11 @@ const config = {
               },
               {
                 label: 'Python',
-                to: '/docs/docs/python/',
+                to: '/docs/python/',
               },
               {
                 label: 'R lang',
-                to: '/docs/docs/r/',
+                to: '/docs/r/',
               },
               {
                 href: "#",
@@ -241,7 +241,7 @@ const config = {
             items: [
               {
                 label: 'Blog',
-                to: '/docs/blog',
+                to: '/blog',
               },
               {
                 label: 'Instagram',
@@ -249,7 +249,7 @@ const config = {
               },
               {
                 label: 'GitHub',
-                href: 'https://github.com/ticaretistatistik/docs',
+                href: 'https://github.com/ticaretistatistik',
               },
             ],
           },


### PR DESCRIPTION
This pull request includes several updates to the `docusaurus.config.js` file to adjust URLs and paths for the Docusaurus site configuration. The main changes involve updating the base URL, project name, and various links to reflect the new repository structure.

### Configuration Updates:

* Updated the `baseUrl` to `/` from `/docs/` to simplify the site path. (`docusaurus.config.js`, [docusaurus.config.jsL19-R24](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL19-R24))
* Changed the `projectName` to `ticaretistatistik.github.io` from `docs` to match the new repository name. (`docusaurus.config.js`, [docusaurus.config.jsL19-R24](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL19-R24))
* Updated the `editUrl` for both the main site and the blog to point to the new repository `ticaretistatistik.github.io`. (`docusaurus.config.js`, [docusaurus.config.jsL48-R55](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL48-R55))
* Corrected the paths for Python and R documentation links to remove the redundant `/docs/` segment. (`docusaurus.config.js`, [docusaurus.config.jsL206-R210](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL206-R210))
* Adjusted the `Blog` link to `/blog` from `/docs/blog` and updated the GitHub link to point directly to the organization instead of the old repository. (`docusaurus.config.js`, [docusaurus.config.jsL244-R252](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aL244-R252))