### PR TITLE
fix: Replace SiWindows icon with FaWindows and use macOS label in python/kurulum.mdx

### DIFF
--- a/docs/python/kurulum.mdx
+++ b/docs/python/kurulum.mdx
@@ -59,14 +59,14 @@ tags: [python,kurulum,programlama]
         url="https://youtu.be/I7HGV6RgVH8" />
   </TabItem>
 
-  <TabItem value="macos" label="Macos">
+  <TabItem value="macos" label="macOS">
     1. `miniconda-vscode-macos.sh` kurulum dosyasını indirin.
-        ![Macos Script Download](/docs/python/macos/miniconda-vscode-macos-download.gif)
+        ![macOS Script Download](/docs/python/macos/miniconda-vscode-macos-download.gif)
     2. Bilgisayarınızındaki `Dosyalar` uygulamasına girin ve `İndirilenler` klasörünü açın.
     3. Bilgisayarınızdaan Finder'a veya Spotlight'a girin ve `Terminal` uygulamasını açın
-        ![MacOS Finder/Spotlight üzerinden Terminal Uygulamasını Açma](/docs/python/macos/mac-terminal-finder-spotlight.jpeg) 
+        ![macOS Finder/Spotlight üzerinden Terminal Uygulamasını Açma](/docs/python/macos/mac-terminal-finder-spotlight.jpeg) 
     4. Terminal uygulaması açıldığında karşınıza aşağıdaki gibi bir ekran çıktığından emin olun.
-        ![MacOS Terminal Arayüzü](/docs/python/macos/mac-terminal-interface.jpeg)
+        ![macOS Terminal Arayüzü](/docs/python/macos/mac-terminal-interface.jpeg)
     5. Açılan terminal ekranında, konumunuzu değiştirmek için aşağıdaki komutlardan sistem diliniz ile uyuşanı seçin.
         ```shell
         cd İndirilenler

--- a/src/components/DownloadFileFeature/index.js
+++ b/src/components/DownloadFileFeature/index.js
@@ -1,5 +1,6 @@
-import { SiWindows, SiApple, SiLinux } from "react-icons/si";
+import { SiApple, SiLinux } from "react-icons/si";
 import { VscVscode } from "react-icons/vsc";
+import { FaWindows } from "react-icons/fa";
 
 import styles from "./styles.module.css";
 
@@ -26,7 +27,7 @@ const DownloadFileFeature = ({ content, file, icon }) => {
         <button
             className={styles.btn}
             onClick={downloadFile}>
-            {icon === "windows" ? <SiWindows /> : icon === "macos" ? <SiApple /> : icon === "linux" ? <SiLinux /> : <VscVscode />}
+            {icon === "windows" ? <FaWindows /> : icon === "macos" ? <SiApple /> : icon === "linux" ? <SiLinux /> : <VscVscode />}
             {content}
         </button>
     );


### PR DESCRIPTION
- Change `SiWindows` icon with `FaWindows` because it's removed from react icons library and causes a build error.
- Use correct `macOS` label in [docs/python/kurulum.mdx](https://github.com/ticaretistatistik/ticaretistatistik.github.io/blob/main/docs/python/kurulum.mdx)